### PR TITLE
Fix TypeScript error in infinite-list ref type

### DIFF
--- a/src/components/infinite-list.tsx
+++ b/src/components/infinite-list.tsx
@@ -12,7 +12,7 @@ interface InfiniteListProps<T> {
     renderItem: (item: T, index: number) => React.ReactNode;
     pageSize?: number;
     className?: string;
-    scrollContainer?: React.RefObject<HTMLDivElement>;
+    scrollContainer?: React.RefObject<HTMLDivElement | null>;
 }
 
 export function InfiniteList<T>({


### PR DESCRIPTION
## Summary
- Fixed TypeScript error TS2322 in day-list.tsx where RefObject<HTMLDivElement | null> couldn't be assigned to RefObject<HTMLDivElement>
- Updated the scrollContainer prop type in InfiniteList component to properly accept null values

## Changes
- Modified `scrollContainer` prop type from `React.RefObject<HTMLDivElement>` to `React.RefObject<HTMLDivElement | null>`
- This aligns with the standard React.useRef pattern which initializes with null

## Test plan
- [x] TypeScript compilation passes without errors
- [x] Build completes successfully
- [x] InfiniteList component continues to work with scroll containers

🤖 Generated with [Claude Code](https://claude.ai/code)