### PR TITLE
Add admin endpoint for sync status monitoring

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as NewCourseRouteImport } from './routes/new-course'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
 
 const NewCourseRoute = NewCourseRouteImport.update({
@@ -23,6 +24,11 @@ const LoginRoute = LoginRouteImport.update({
   path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -31,30 +37,34 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/login': typeof LoginRoute
   '/new-course': typeof NewCourseRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/login': typeof LoginRoute
   '/new-course': typeof NewCourseRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/login': typeof LoginRoute
   '/new-course': typeof NewCourseRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/new-course'
+  fullPaths: '/' | '/admin' | '/login' | '/new-course'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/new-course'
-  id: '__root__' | '/' | '/login' | '/new-course'
+  to: '/' | '/admin' | '/login' | '/new-course'
+  id: '__root__' | '/' | '/admin' | '/login' | '/new-course'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminRoute: typeof AdminRoute
   LoginRoute: typeof LoginRoute
   NewCourseRoute: typeof NewCourseRoute
 }
@@ -75,6 +85,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminRoute: AdminRoute,
   LoginRoute: LoginRoute,
   NewCourseRoute: NewCourseRoute,
 }

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -45,7 +45,9 @@ function AdminPage() {
     const syncMutation = useMutation({
         mutationFn: async () => {
             const { data } = await apiClient.POST("/sync-courses-temporal", {
-                body: {},
+                body: {
+                    force_refresh: false,
+                },
             });
             return data;
         },

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,0 +1,187 @@
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { useAuth } from "@/lib/auth-context";
+import apiClient from "@/lib/api-client";
+import { useState, useEffect } from "react";
+
+export const Route = createFileRoute("/admin")({
+    component: AdminPage,
+});
+
+interface SyncStatus {
+    job_sync_group_id: string;
+    status: "running" | "completed";
+    created_at: string;
+    completed_at?: string;
+    job_syncs_created: number;
+    result?: {
+        job_syncs_created: number;
+        courses_scraped: number;
+        assignments_found: number;
+        due_dates_found: number;
+        duration_seconds: number;
+    };
+}
+
+function AdminPage() {
+    const { user } = useAuth();
+    const [status, setStatus] = useState<SyncStatus | null>(null);
+    const [isPolling, setIsPolling] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Check if user email is the admin email
+    if (!user || user.email !== "dh3243@columbia.edu") {
+        return <Navigate to="/" />;
+    }
+
+    const fetchSyncStatus = async () => {
+        try {
+            const { data, error: apiError } = await apiClient.GET(
+                "/sync-courses-temporal/latest-status",
+                {}
+            );
+
+            if (apiError) {
+                setError("Failed to fetch sync status");
+                console.error(apiError);
+                setIsPolling(false);
+            } else {
+                setStatus(data as SyncStatus);
+                setError(null);
+
+                // Stop polling if status is completed
+                if (data && (data as SyncStatus).status === "completed") {
+                    setIsPolling(false);
+                }
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Unknown error");
+            console.error(err);
+            setIsPolling(false);
+        }
+    };
+
+    const handleCheckStatus = () => {
+        setIsPolling(true);
+        fetchSyncStatus();
+    };
+
+    const handleStopPolling = () => {
+        setIsPolling(false);
+    };
+
+    // Polling effect
+    useEffect(() => {
+        if (!isPolling) return;
+
+        const interval = setInterval(() => {
+            fetchSyncStatus();
+        }, 2000); // Poll every 2 seconds
+
+        return () => clearInterval(interval);
+    }, [isPolling]);
+
+    return (
+        <div className="flex flex-col h-screen items-center justify-center p-8">
+            <div className="max-w-2xl w-full space-y-6">
+                <h1 className="text-3xl font-bold">Admin Panel</h1>
+
+                <div className="space-y-4">
+                    <div className="flex gap-2">
+                        <button
+                            onClick={handleCheckStatus}
+                            disabled={isPolling}
+                            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+                        >
+                            {isPolling ? "Polling..." : "Check Sync Status"}
+                        </button>
+
+                        {isPolling && (
+                            <button
+                                onClick={handleStopPolling}
+                                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                            >
+                                Stop Polling
+                            </button>
+                        )}
+                    </div>
+
+                    {error && (
+                        <div className="p-4 bg-red-100 text-red-700 rounded">
+                            Error: {error}
+                        </div>
+                    )}
+
+                    {status && (
+                        <div className="p-4 bg-white border rounded-lg shadow">
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <h2 className="text-xl font-semibold">Sync Status</h2>
+                                    <span
+                                        className={`px-3 py-1 rounded-full text-sm font-medium ${
+                                            status.status === "completed"
+                                                ? "bg-green-100 text-green-800"
+                                                : "bg-yellow-100 text-yellow-800"
+                                        }`}
+                                    >
+                                        {status.status}
+                                    </span>
+                                </div>
+
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <p className="text-sm text-gray-600">Job Group ID</p>
+                                        <p className="font-mono text-sm">{status.job_sync_group_id}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-sm text-gray-600">Job Syncs Created</p>
+                                        <p className="font-semibold">{status.job_syncs_created}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-sm text-gray-600">Created At</p>
+                                        <p className="text-sm">
+                                            {new Date(status.created_at).toLocaleString()}
+                                        </p>
+                                    </div>
+                                    {status.completed_at && (
+                                        <div>
+                                            <p className="text-sm text-gray-600">Completed At</p>
+                                            <p className="text-sm">
+                                                {new Date(status.completed_at).toLocaleString()}
+                                            </p>
+                                        </div>
+                                    )}
+                                </div>
+
+                                {status.result && (
+                                    <div className="mt-4 pt-4 border-t">
+                                        <h3 className="font-semibold mb-2">Results</h3>
+                                        <div className="grid grid-cols-2 gap-3">
+                                            <div>
+                                                <p className="text-sm text-gray-600">Courses Scraped</p>
+                                                <p className="font-semibold">{status.result.courses_scraped}</p>
+                                            </div>
+                                            <div>
+                                                <p className="text-sm text-gray-600">Assignments Found</p>
+                                                <p className="font-semibold">{status.result.assignments_found}</p>
+                                            </div>
+                                            <div>
+                                                <p className="text-sm text-gray-600">Due Dates Found</p>
+                                                <p className="font-semibold">{status.result.due_dates_found}</p>
+                                            </div>
+                                            <div>
+                                                <p className="text-sm text-gray-600">Duration</p>
+                                                <p className="font-semibold">
+                                                    {status.result.duration_seconds.toFixed(2)}s
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/types/schema.gen.ts
+++ b/src/types/schema.gen.ts
@@ -153,6 +153,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sync-courses-temporal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync Courses Temporal
+         * @description Trigger course synchronization using Temporal workflow.
+         *
+         *     This endpoint starts an asynchronous workflow that:
+         *     1. Creates sync jobs for specified courses (or all user courses)
+         *     2. Scrapes course websites in parallel
+         *     3. Finds assignments in parallel
+         *     4. Finds due dates in parallel
+         *
+         *     Returns immediately with workflow ID for tracking.
+         */
+        post: operations["sync_courses_temporal_sync_courses_temporal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sync-courses-temporal/latest-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Latest Job Sync Group Status */
+        get: operations["get_latest_job_sync_group_status_sync_courses_temporal_latest_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -211,6 +256,34 @@ export interface components {
             title?: string | null;
             /** Color */
             color: string;
+        };
+        /**
+         * CourseSyncTemporalRequest
+         * @description Request model for Temporal course sync endpoint.
+         */
+        CourseSyncTemporalRequest: {
+            /** Course Ids */
+            course_ids?: string[] | null;
+            /**
+             * Force Refresh
+             * @default false
+             */
+            force_refresh: boolean;
+        };
+        /**
+         * CourseSyncTemporalResponse
+         * @description Response model for Temporal course sync initiation.
+         */
+        CourseSyncTemporalResponse: {
+            /** Workflow Id */
+            workflow_id: string;
+            /**
+             * Status
+             * @default started
+             */
+            status: string;
+            /** Message */
+            message: string;
         };
         /**
          * CourseWithColor
@@ -465,6 +538,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_courses_temporal_sync_courses_temporal_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CourseSyncTemporalRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CourseSyncTemporalResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_latest_job_sync_group_status_sync_courses_temporal_latest_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Created admin-protected route at `/admin` that restricts access to `dh3243@columbia.edu`
- Implemented polling functionality that fetches `/sync-courses-temporal/latest-status` every 2 seconds
- Auto-stops polling when sync job completes
- Displays structured status UI with job details and results

## Features
- Email-based admin access control with redirect to home for unauthorized users
- Real-time polling with manual stop control
- Status badge (green for completed, yellow for running)
- Detailed results display including courses scraped, assignments found, due dates, and duration

## Test plan
- [ ] Verify admin user (dh3243@columbia.edu) can access `/admin`
- [ ] Verify non-admin users are redirected to home
- [ ] Test polling functionality with running sync job
- [ ] Verify polling stops automatically when job completes
- [ ] Test manual stop polling button

🤖 Generated with [Claude Code](https://claude.com/claude-code)